### PR TITLE
Fix attribute error in read_checks function

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -247,9 +247,19 @@
     "#export\n",
     "def read_checks(fmod):\n",
     "    \"Evaluated contents of `download_checks.py`\"\n",
-    "    if not fmod.exists(): return {}\n",
+    "    if fmod == {} or not fmod.exists(): return {}\n",
     "    txt = fmod.read_text()\n",
     "    return eval(txt) if txt else {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bc2cfbd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert read_checks({}) == {}"
    ]
   },
   {

--- a/fastdownload/core.py
+++ b/fastdownload/core.py
@@ -39,7 +39,7 @@ def checks_module(module):
 # Cell
 def read_checks(fmod):
     "Evaluated contents of `download_checks.py`"
-    if not fmod.exists(): return {}
+    if fmod == {} or not fmod.exists(): return {}
     txt = fmod.read_text()
     return eval(txt) if txt else {}
 


### PR DESCRIPTION
Closes https://github.com/fastai/fastdownload/issues/11

I tried the first example on the fastdownload README page, using the url of one of the standard fastai datasets available on S3. It raised an attribute error, because variable `fmod` was an empty dictionary instead of the expected pathlib object. 

```python
from fastdownload import FastDownload

url = 'https://s3.amazonaws.com/fast-ai-sample/mnist_tiny.tgz'
d = FastDownload()
path = d.get(url)
```

```python-traceback
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-50-389349d26777> in <module>
      3 url = 'https://s3.amazonaws.com/fast-ai-sample/mnist_tiny.tgz'
      4 d = FastDownload()
----> 5 path = d.get(url)

~/anaconda3/envs/napari-dev/lib/python3.9/site-packages/fastdownload/core.py in get(self, url, extract_key, force)
    119             data = self.data_path(extract_key, urldest(url, self.arch_path()))
    120             if data.exists(): return data
--> 121         self.download(url, force=force)
    122         return self.extract(url, extract_key=extract_key, force=force)

~/anaconda3/envs/napari-dev/lib/python3.9/site-packages/fastdownload/core.py in download(self, url, force)
     94         "Download `url` to archive path, unless exists and `self.check` fails and not `force`"
     95         self.arch_path().mkdir(exist_ok=True, parents=True)
---> 96         return download_and_check(url, urldest(url, self.arch_path()), self.module, force)
     97 
     98     def rm(self, url, rm_arch=True, rm_data=True, extract_key='data'):

~/anaconda3/envs/napari-dev/lib/python3.9/site-packages/fastdownload/core.py in download_and_check(url, fpath, fmod, force)
     61     "Download `url` to `fpath`, unless exists and `check` fails and not `force`"
     62     if not force and fpath.exists():
---> 63         if check(fmod, url, fpath): return fpath
     64         else: print("Downloading a new version of this dataset...")
     65     res = download_url(url, fpath)

~/anaconda3/envs/napari-dev/lib/python3.9/site-packages/fastdownload/core.py in check(fmod, url, fpath)
     47 def check(fmod, url, fpath):
     48     "Check whether size and hash of `fpath` matches stored data for `url` or data is missing"
---> 49     checks = read_checks(fmod).get(url)
     50     return not checks or path_stats(fpath)==checks
     51 

~/anaconda3/envs/napari-dev/lib/python3.9/site-packages/fastdownload/core.py in read_checks(fmod)
     40 def read_checks(fmod):
     41     "Evaluated contents of `download_checks.py`"
---> 42     if not fmod.exists(): return {}
     43     txt = fmod.read_text()
     44     return eval(txt) if txt else {}

AttributeError: 'dict' object has no attribute 'exists'

```

This PR avoids that error, by checking whether `fmod` is an empty dictionary before continuing.
